### PR TITLE
 use a date format that won't be mangled by flatgithub

### DIFF
--- a/bin/update_data.py
+++ b/bin/update_data.py
@@ -57,7 +57,7 @@ def fetch_data(start_date, end_date):
 
 def update_data(today_dt):
     end_date = today_dt.strftime("%Y-%m-%d")
-    start_date = (today_dt - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    start_date = (today_dt - datetime.timedelta(days=1)).strftime("%m-%d-%Y")
 
     resp_data = fetch_data(start_date, end_date)
 


### PR DESCRIPTION
flatgithub is displaying euro-formatted dates as one-day-off in the UI for some reason. Since flatgithub isn't receiving updates, this changes the date format to one that is displayed without mangling

I mangled the main branch of my fork in order to demonstrate the change. Here is the [raw data](https://github.com/lonnen/socorro-stats/blob/b9500947813fe9aa4083c0ef59448bda980d1e58/socorro_stats.json) and the [correct presentation](https://flatgithub.com/lonnen/socorro-stats?filename=socorro_stats.json&sha=b9500947813fe9aa4083c0ef59448bda980d1e58).

patch dictated, never run
-L